### PR TITLE
FEATURE: PHPStan extension for composite projections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Wwwision\\DCBLibrary\\Tests\\": "tests/"
+      "Wwwision\\DCBLibrary\\PHPStanExtensions\\": "phpstan-extensions/"
     }
   },
   "scripts": {

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,4 @@
+services:
+  - class: Wwwision\DCBLibrary\PHPStanExtensions\CompositeProjectorCreateReturnTypeExtension
+    tags:
+      - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/phpstan-extensions/CompositeProjectorCreateReturnTypeExtension.php
+++ b/phpstan-extensions/CompositeProjectorCreateReturnTypeExtension.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\DCBLibrary\PHPStanExtensions;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectShapeType;
+use PHPStan\Type\Type;
+use Wwwision\DCBLibrary\Projection\CompositeProjection;
+
+class CompositeProjectorCreateReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return CompositeProjection::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'create';
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $args = $methodCall->getArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $firstArg = $args[0];
+        if (!$firstArg instanceof Arg) {
+            return null;
+        }
+        $arrayType = $scope->getType($firstArg->value);
+        if (!$arrayType instanceof ConstantArrayType) {
+            return null;
+        }
+        $properties = [];
+        $keyTypes = $arrayType->getKeyTypes();
+        $valueTypes = $arrayType->getValueTypes();
+
+        $keyCount = count($keyTypes);
+        for ($i = 0; $i < $keyCount; $i++) {
+            $keyType = $keyTypes[$i];
+            $valueType = $valueTypes[$i];
+
+            // Extract string key from constant string type
+            if ($keyType->isConstantScalarValue()->yes()) {
+                $keyValue = $keyType->getConstantScalarValues()[0];
+                if (is_string($keyValue)) {
+                    // Extract generic type from ClosureProjector
+                    if ($valueType instanceof GenericObjectType) {
+                        $templateTypes = $valueType->getTypes();
+                        if (!empty($templateTypes)) {
+                            $propertyType = reset($templateTypes);
+                        } else {
+                            $propertyType = new MixedType();
+                        }
+                    } else {
+                        $propertyType = new MixedType();
+                    }
+
+                    $properties[$keyValue] = $propertyType;
+                }
+            }
+        }
+
+        if (empty($properties)) {
+            return null;
+        }
+        // Create object shape type
+        $stateType = new ObjectShapeType($properties, []);
+
+        // Return CompositeProjector<StateType>
+        return new GenericObjectType(CompositeProjection::class, [$stateType]);
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+includes:
+  - extension.neon
 parameters:
   level: max
   paths:


### PR DESCRIPTION
Providing type safety for composed projections like:

```php
\PHPStan\dumpType(CompositeProjection::create([
    'foo' => ClosureProjection::create(initialState: 'string'),
    'bar' => ClosureProjection::create(initialState: false),
]));

// Dumped type: Wwwision\DCBLibrary\Projection\CompositeProjection<object{foo: string, bar: bool}>
```