### PR TITLE
FEATURE: Add `ValueIsNull` criteria

### DIFF
--- a/src/Projection/PersistentProjection/Filter/Criteria/AndCriteria.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/AndCriteria.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Binary operation that conjunctively combines two criteria:
  *   "prop1 = 'foo' AND prop2 = 'bar'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class AndCriteria implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/NegateCriteria.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/NegateCriteria.php
@@ -10,8 +10,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Or:
  *   "prop1 != 'foo'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class NegateCriteria implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/OrCriteria.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/OrCriteria.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Binary operation that disjunctively combines two criteria:
  *   "prop1 = 'foo' OR prop2 = 'bar'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class OrCriteria implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/PersistentProjectionFilterCriteria.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/PersistentProjectionFilterCriteria.php
@@ -7,7 +7,7 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
 /**
  * Common marker interface for property value filter criteria
  * @internal This is not meant to be implemented by external packages!
- * @phpstan-sealed AndCriteria|NegateCriteria|OrCriteria|ValueContains|ValueEndsWith|ValueEquals|ValueGreaterThan|ValueGreaterThanOrEqual|ValueLessThan|ValueLessThanOrEqual|ValueStartsWith
+ * @phpstan-sealed AndCriteria|NegateCriteria|OrCriteria|ValueContains|ValueEndsWith|ValueEquals|ValueGreaterThan|ValueGreaterThanOrEqual|ValueIsNull|ValueLessThan|ValueLessThanOrEqual|ValueStartsWith
  */
 interface PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueContains.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueContains.php
@@ -11,8 +11,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property contains the specified string (case-insensitive)
  *      "prop1 *=~ 'foo'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueContains implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueEndsWith.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueEndsWith.php
@@ -11,8 +11,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property ends with the specified string (case-insensitive)
  *      "prop1 $=~ 'foo'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueEndsWith implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueEquals.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueEquals.php
@@ -11,8 +11,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property is equal to "foo" ignoring the case (e.g. "Foo" and "FOO" would match as well)
  *     "stringProp =~ 'foo'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueEquals implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueGreaterThan.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueGreaterThan.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property is greater than the specified value
  *     "stringProp > 'foo' OR intProp > 123 OR floatProp > 123.45"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueGreaterThan implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueGreaterThanOrEqual.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueGreaterThanOrEqual.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property is greater than or equal to the specified value
  *     "stringProp >= 'foo' OR intProp >= 123 OR floatProp >= 123.45"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueGreaterThanOrEqual implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueIsNull.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueIsNull.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
+
+/**
+ * Criteria that matches if a property is NULL or not existent
+ */
+final readonly class ValueIsNull implements PersistentProjectionFilterCriteria
+{
+    private function __construct(
+        public string $propertyName,
+    ) {
+    }
+
+    public static function create(string $propertyName): self
+    {
+        return new self($propertyName);
+    }
+}

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueLessThan.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueLessThan.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property is less than the specified value
  *     "stringProp< < 'foo' OR intProp < 123 OR floatProp < 123.45"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueLessThan implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueLessThanOrEqual.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueLessThanOrEqual.php
@@ -8,8 +8,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property is less than or equal to the specified value
  *     "stringProp <= 'foo' OR intProp <= 123 OR floatProp <= 123.45"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueLessThanOrEqual implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Filter/Criteria/ValueStartsWith.php
+++ b/src/Projection/PersistentProjection/Filter/Criteria/ValueStartsWith.php
@@ -11,8 +11,6 @@ namespace Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria;
  * Criteria that matches if a property starts with the specified string (case-insensitive)
  *      "prop1 ^=~ 'foo'"
  *
- * @see PropertyValueCriteriaParser
- * @api
  */
 final readonly class ValueStartsWith implements PersistentProjectionFilterCriteria
 {

--- a/src/Projection/PersistentProjection/Storage/DoctrinePersistentProjectionStorage.php
+++ b/src/Projection/PersistentProjection/Storage/DoctrinePersistentProjectionStorage.php
@@ -25,6 +25,7 @@ use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueEnd
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueEquals;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueGreaterThan;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueGreaterThanOrEqual;
+use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueIsNull;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueLessThan;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueLessThanOrEqual;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueStartsWith;
@@ -155,6 +156,7 @@ final class DoctrinePersistentProjectionStorage implements PersistentProjectionS
             ValueLessThan::class => $this->compareValueStatement($queryBuilder, $criteria->propertyName, $criteria->value, '<'),
             ValueLessThanOrEqual::class => $this->compareValueStatement($queryBuilder, $criteria->propertyName, $criteria->value, '<='),
             ValueStartsWith::class => $this->searchValueStatement($queryBuilder, $criteria->propertyName, $criteria->value . '%', $criteria->caseSensitive),
+            ValueIsNull::class => 'JSON_TYPE(' . $this->extractPropertyValue($criteria->propertyName) . ') = \'NULL\'',
             default => throw new \InvalidArgumentException(sprintf('Invalid/unsupported filter criteria "%s"', get_debug_type($criteria)), 1679561062),
         };
     }

--- a/src/Projection/PersistentProjection/Storage/InMemoryPersistentProjectionStorage.php
+++ b/src/Projection/PersistentProjection/Storage/InMemoryPersistentProjectionStorage.php
@@ -15,6 +15,7 @@ use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueEnd
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueEquals;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueGreaterThan;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueGreaterThanOrEqual;
+use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueIsNull;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueLessThan;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueLessThanOrEqual;
 use Wwwision\DCBLibrary\Projection\PersistentProjection\Filter\Criteria\ValueStartsWith;
@@ -108,6 +109,7 @@ final class InMemoryPersistentProjectionStorage implements PersistentProjectionS
             ValueGreaterThanOrEqual::class => isset($state[$criteria->propertyName]) && $state[$criteria->propertyName] >= $criteria->value,
             ValueLessThan::class => isset($state[$criteria->propertyName]) && $state[$criteria->propertyName] < $criteria->value,
             ValueLessThanOrEqual::class => isset($state[$criteria->propertyName]) && $state[$criteria->propertyName] <= $criteria->value,
+            ValueIsNull::class => !isset($state[$criteria->propertyName]),
             default => throw new \InvalidArgumentException(sprintf('Invalid/unsupported value criteria "%s"', get_debug_type($criteria)), 1759922446),
         };
     }


### PR DESCRIPTION
to allow Persistent Projections to be filtered by null/non-null properties